### PR TITLE
fixed tsubcode withdrawal

### DIFF
--- a/tw-pnl.py
+++ b/tw-pnl.py
@@ -785,7 +785,7 @@ def check(all_wk, output_summary, output_csv, output_excel, tax_output, show, ve
         if tsubcode == 'Deposit':
             if description != 'ACH DEPOSIT':
                 tax_free = True
-        if tsubcode == 'Withdrawal' and not isnan(symbol):
+        if tsubcode == 'Withdrawal':
             tax_free = True
         # Stillhalterpraemien gelten als Zufluss und nicht als Anschaffung
         # und sind daher steuer-neutral:


### PR DESCRIPTION
I checked in my dataset and withdrawals are always without symbol.

Output before:
```
python tw-pnl.py --assume-individual-stock --debug withdrawal.csv
Date/Time                         2018-04-16 23:00:00
Transaction Code                       Money Movement
Transaction Subcode                        Withdrawal
Symbol                                            NaN
Buy/Sell                                          NaN
Open/Close                                        NaN
Quantity                                            0
Expiration Date                                   NaN
Strike                                            NaN
Call/Put                                          NaN
Price                                             NaN
Fees                                              0.0
Amount                                          -1.24
Description            FROM 03/16 THRU 04/15 @ 8    %
Account Reference                     Individual...60
found
Traceback (most recent call last):
  File "/Users/avion/Documents/programming/accounting/tastyworks-pnl/tw-pnl.py", line 1146, in <module>
    main(sys.argv[1:])
  File "/Users/avion/Documents/programming/accounting/tastyworks-pnl/tw-pnl.py", line 1143, in main
    check(all_wk, output_summary, output_csv, output_excel, tax_output, show, verbose, debug)
  File "/Users/avion/Documents/programming/accounting/tastyworks-pnl/tw-pnl.py", line 1054, in check
    stats = get_summary(new_wk, tax_output, min_year, max_year)
  File "/Users/avion/Documents/programming/accounting/tastyworks-pnl/tw-pnl.py", line 525, in get_summary
    raise ValueError(f'tax_free is False for type "{type}". Full row: "{new_wk.iloc[i]}"')
ValueError: tax_free is False for type "Zinsen". Full row: "datetime                         2018-04-16 23:00
type                                       Zinsen
pnl                                         -1.00
eur_amount                                  -1.00
usd_amount                                -1.2400
fees                                       0.0000
eurusd                                     1.2370
quantity                                        0
asset                                    interest
symbol                                        NaN
callput                                       NaN
tax_free                                    False
usd_gains                                    0.00
usd_gains_notax                              0.00
description        FROM 03/16 THRU 04/15 @ 8    %
cash_total                                  -1.24
net_total                                   -1.24
Name: 0, dtype: object"
```

Output with my fix:

```
python tw-pnl.py --assume-individual-stock --debug withdrawal.csv
Date/Time                         2018-04-16 23:00:00
Transaction Code                       Money Movement
Transaction Subcode                        Withdrawal
Symbol                                            NaN
Buy/Sell                                          NaN
Open/Close                                        NaN
Quantity                                            0
Expiration Date                                   NaN
Strike                                            NaN
Call/Put                                          NaN
Price                                             NaN
Fees                                              0.0
Amount                                          -1.24
Description            FROM 03/16 THRU 04/15 @ 8    %
Account Reference                     Individual...60
                                        2018  total
Einzahlungen                            0.00   0.00
Auszahlungen                            0.00   0.00
Brokergebühren                          0.00   0.00
Alle Gebühren in USD                    0.00   0.00
Alle Gebühren                           0.00   0.00
Währungsgewinne USD                     0.00   0.00
Währungsgewinne USD (steuerfrei)        0.00   0.00
Währungsgewinne USD Gesamt              0.00   0.00
Krypto-Gewinne                          0.00   0.00
Krypto-Verluste                         0.00   0.00
Anlage SO                               0.00   0.00
Anlage SO Steuerbetrag                  0.00   0.00
Anlage SO Verlustvortrag                0.00   0.00
Investmentfondsgewinne                  0.00   0.00
Investmentfondsverluste                 0.00   0.00
Anlage KAP-INV                          0.00   0.00
Aktiengewinne (Z20)                     0.00   0.00
Aktienverluste (Z23)                    0.00   0.00
Aktien Gesamt                           0.00   0.00
Aktien Steuerbetrag                     0.00   0.00
Aktien Verlustvortrag                   0.00   0.00
Sonstige Gewinne                        0.00   0.00
Sonstige Verluste                       0.00   0.00
Sonstige Gesamt                         0.00   0.00
Stillhalter-Gewinne                     0.00   0.00
Stillhalter-Verluste                    0.00   0.00
Stillhalter Gesamt                      0.00   0.00
Durchschnitt behaltene Prämien pro Tag  0.00   0.00
Stillhalter-Gewinne Calls (FIFO)        0.00   0.00
Stillhalter-Verluste Calls (FIFO)       0.00   0.00
Stillhalter Calls Gesamt (FIFO)         0.00   0.00
Stillhalter-Gewinne Puts (FIFO)         0.00   0.00
Stillhalter-Verluste Puts (FIFO)        0.00   0.00
Stillhalter Puts Gesamt (FIFO)          0.00   0.00
Stillhalter-Gewinne (FIFO)              0.00   0.00
Stillhalter-Verluste (FIFO)             0.00   0.00
Stillhalter Gesamt (FIFO)               0.00   0.00
Long-Optionen-Gewinne                   0.00   0.00
Long-Optionen-Verluste                  0.00   0.00
Long-Optionen Gesamt                    0.00   0.00
Future-Gewinne                          0.00   0.00
Future-Verluste                         0.00   0.00
Future Gesamt                           0.00   0.00
zusätzliche Ordergebühren               0.00   0.00
Dividenden                              0.00   0.00
bezahlte Dividenden                     0.00   0.00
Quellensteuer (Z41)                     0.00   0.00
Zinseinnahmen                           0.00   0.00
Zinsausgaben                           -1.00  -1.00
Zinsen Gesamt                          -1.00  -1.00
Z19 Ausländische Kapitalerträge        -1.00  -1.00
Z21 Termingeschäftsgewinne+Stillhalter  0.00   0.00
Z24 Termingeschäftsverluste             0.00   0.00
KAP+KAP-INV                            -1.00  -1.00
KAP+KAP-INV KErSt+Soli                  0.00   0.00
KAP+KAP-INV Verlustvortrag             -0.26  -0.26
Cash Balance USD                       -1.24  -1.24
Net Liquidating Value                  -1.24  -1.24
```

Test data is attached.

[withdrawal.csv](https://github.com/laroche/tastyworks-pnl/files/9594544/withdrawal.csv)
